### PR TITLE
fix for #9

### DIFF
--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ir"
-version = "0.2.74"
+version = "0.2.75"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"

--- a/fugue-ir/src/disassembly/walker.rs
+++ b/fugue-ir/src/disassembly/walker.rs
@@ -376,6 +376,7 @@ impl<'b, 'z> ParserContext<'b, 'z> {
             return Ok(())
         }
 
+        let curr_address = self.address.clone();
         let commits = self.context_commit.clone();
         let mut nwalker = ParserWalker::<'b, 'c, 'z>::new(self);
 
@@ -397,11 +398,11 @@ impl<'b, 'z> ParserContext<'b, 'z> {
             }
 
             if commit.flow {
-                db.set_context_change_point(address, commit.number, commit.mask, commit.value);
+                db.set_context_change_point(curr_address, address, commit.number, commit.mask, commit.value);
             } else {
                 let naddress = address.clone() + 1usize;
                 if naddress.offset() < address.offset() {
-                    db.set_context_change_point(address, commit.number, commit.mask, commit.value);
+                    db.set_context_change_point(curr_address, address, commit.number, commit.mask, commit.value);
                 } else {
                     db.set_context_region(address, Some(naddress), commit.number, commit.mask, commit.value);
                 }


### PR DESCRIPTION
This fixes the following issues:
- When a default variable was set, only the value was set in the `FreeArray`, whereas both the value and mask should have been set
- When a context change involving flow occurred, if the context flowed from an address less than the current one and if the current address had no non-default context set, then the context change would propagate through the current address.

This fix addresses the issues by::
- Setting the mask correctly when setting a default value for a variable
- When performing a context change involving flow, performs a split in the partition map to commit the context of the current instruction