### PR TITLE
Execable-readable-seg

### DIFF
--- a/fugue-arch/Cargo.toml
+++ b/fugue-arch/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-fugue-bytes = { path = "../fugue-bytes", version = "0.2", registry = "fugue" }
+fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 unicase = "2.6"

--- a/fugue-arch/Cargo.toml
+++ b/fugue-arch/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.4"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [dependencies]
 fugue-bytes = { path = "../fugue-bytes", version = "0.2" }

--- a/fugue-bv/Cargo.toml
+++ b/fugue-bv/Cargo.toml
@@ -12,7 +12,7 @@ fixed-u128 = []
 bigint = ["rug"]
 
 [dependencies]
-fugue-bytes = { path = "../fugue-bytes", version = "0.2", registry = "fugue" }
+fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
 num-integer = "0.1"
 num-traits = "0.2"
 paste = "1"

--- a/fugue-bv/Cargo.toml
+++ b/fugue-bv/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.34"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]

--- a/fugue-bytes/Cargo.toml
+++ b/fugue-bytes/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.2"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [features]
 default = []

--- a/fugue-core/Cargo.toml
+++ b/fugue-core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.8"
 authors = ["Sam Thomas <st@xv.ax>", "Zitai Chen <zitaichen@outlook.com>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]

--- a/fugue-core/Cargo.toml
+++ b/fugue-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fugue"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Sam Thomas <st@xv.ax>", "Zitai Chen <zitaichen@outlook.com>"]
 edition = "2021"
 license = "MIT"
 
 [features]
-default = ["bigint", "db", "fp"]
+default = ["bigint"]
 
 bigint = ["fugue-bv/bigint", "fugue-db?/bigint", "fugue-ir/bigint"]
 fixed-u64 = ["fugue-bv/fixed-u64", "fugue-db?/fixed-u64", "fugue-ir/fixed-u64"]
@@ -19,9 +19,9 @@ db = ["fugue-db"]
 fp = ["bigint", "fugue-fp"]
 
 [dependencies]
-fugue-arch = { path = "../fugue-arch", version = "0.2", registry = "fugue" }
-fugue-bv = { path = "../fugue-bv", version = "0.2", registry = "fugue", default-features = false }
-fugue-bytes = { path = "../fugue-bytes", version = "0.2", registry = "fugue" }
-fugue-db = { path = "../fugue-db", version = "0.2", registry = "fugue", default-features = false, optional = true }
-fugue-fp = { path = "../fugue-fp", version = "0.2", registry = "fugue", optional = true }
-fugue-ir = { path = "../fugue-ir", version = "0.2", registry = "fugue", default-features = false }
+fugue-arch = { path = "../fugue-arch", version = "0.2" }
+fugue-bv = { path = "../fugue-bv", version = "0.2", default-features = false }
+fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
+fugue-db = { path = "../fugue-db", version = "0.2", default-features = false, optional = true }
+fugue-fp = { path = "../fugue-fp", version = "0.2", optional = true }
+fugue-ir = { path = "../fugue-ir", version = "0.2", default-features = false }

--- a/fugue-db/Cargo.toml
+++ b/fugue-db/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 build = "build.rs"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]

--- a/fugue-db/Cargo.toml
+++ b/fugue-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-db"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 build = "build.rs"
@@ -13,12 +13,12 @@ fixed-u64 = ["fugue-ir/fixed-u64"]
 fixed-u128 = ["fugue-ir/fixed-u128"]
 
 [dependencies]
-fugue-arch = { path = "../fugue-arch", version = "0.2", registry = "fugue" }
-fugue-bytes = { path = "../fugue-bytes", version = "0.2", registry = "fugue" }
-fugue-ir = { path = "../fugue-ir", version = "0.2", registry = "fugue", default-features = false }
+fugue-arch = { path = "../fugue-arch", version = "0.2" }
+fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
+fugue-ir = { path = "../fugue-ir", version = "0.2", default-features = false }
 
 educe = "0.4"
-flatbuffers = "22.10.26"
+flatbuffers = "23.1.21"
 fs_extra = "1.2"
 iset = "0.2"
 ouroboros = "0.9"
@@ -31,4 +31,4 @@ which = "4"
 url = "2.2"
 
 [build-dependencies]
-flatcc = "22.10.26"
+flatcc = "23.1.21"

--- a/fugue-db/src/basic_block.rs
+++ b/fugue-db/src/basic_block.rs
@@ -127,7 +127,7 @@ impl<'db> BasicBlock<'db> {
             segment: segments
                 .iter(address..address + reader.size_() as u64)
                 .find_map(|(_, s)| {
-                    if s.is_code() || s.is_external() {
+                    if s.is_code() || s.is_external() || s.is_executable() || s.is_readable() {
                         Some(s)
                     } else {
                         None

--- a/fugue-db/src/function.rs
+++ b/fugue-db/src/function.rs
@@ -53,7 +53,7 @@ impl<'db> Function<'db> {
             segment: segments
                 .iter(address..address + 1)
                 .find_map(|(_, s)| {
-                    if s.is_code() || s.is_external() {
+                    if s.is_code() || s.is_external() || s.is_executable() || s.is_readable() {
                         Some(s.id())
                     } else {
                         None

--- a/fugue-fp/Cargo.toml
+++ b/fugue-fp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-fugue-bv = { path = "../fugue-bv", version = "0.2", features = ["bigint"], default-features = false, registry = "fugue" }
-fugue-ir = { path = "../fugue-ir", version = "0.2", registry = "fugue" }
+fugue-bv = { path = "../fugue-bv", version = "0.2", features = ["bigint"], default-features = false }
+fugue-ir = { path = "../fugue-ir", version = "0.2" }
 rug = { version = "1", features = ["float"] }
 thiserror = "1"

--- a/fugue-fp/Cargo.toml
+++ b/fugue-fp/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.2"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [dependencies]
 fugue-bv = { path = "../fugue-bv", version = "0.2", features = ["bigint"], default-features = false }

--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.88"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
+description = "A binary analysis framework written in Rust"
+homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]

--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -17,9 +17,9 @@ extra-logging = []
 [dependencies]
 ahash = { version = "0.8", features = ["serde"] }
 bumpalo = { version = "3.12", features = ["boxed", "collections"] }
-fugue-arch = { path = "../fugue-arch", version = "0.2", registry = "fugue" }
-fugue-bv = { path = "../fugue-bv", version = "0.2", registry = "fugue", default-features = false }
-fugue-bytes = { path = "../fugue-bytes", version = "0.2", registry = "fugue" }
+fugue-arch = { path = "../fugue-arch", version = "0.2" }
+fugue-bv = { path = "../fugue-bv", version = "0.2", default-features = false }
+fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
 iset = { version = "0.2", features = ["serde"] }
 itertools = "0.10"
 log = "0.4"

--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ir"
-version = "0.2.88"
+version = "0.2.89"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"

--- a/fugue-ir/src/disassembly/pattern.rs
+++ b/fugue-ir/src/disassembly/pattern.rs
@@ -7,6 +7,7 @@ use crate::disassembly::walker::ParserWalker;
 use crate::disassembly::error::Error;
 
 use std::mem::size_of;
+use std::ops::Range;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -75,6 +76,220 @@ impl PatternExpression {
             Self::Constant { value, .. } => Some(*value),
             _ => None,
         }
+    }
+
+    pub fn value_with<'b, 'c, 'z>(&'b self, walker: &mut ParserWalker<'b, 'c, 'z>, symbols: &'b SymbolTable) -> Result<(i64, Option<Range<u32>>), Error> {
+        Ok(match self {
+            Self::TokenField {
+                big_endian,
+                sign_bit,
+                bit_start,
+                bit_end,
+                byte_start,
+                byte_end,
+                shift,
+            } => {
+                let size = byte_end - byte_start + 1;
+                let mut res = 0i64;
+                let mut start = *byte_start as isize;
+                let mut tsize = size as isize;
+
+                while tsize >= size_of::<u32>() as isize {
+                    let tmp = walker.instruction_bytes(start as usize, size_of::<u32>())?;
+                    res = res.checked_shl(8 * size_of::<u32>() as u32).unwrap_or(0);
+                    res = (res as u64 | tmp as u64) as i64;
+                    start += size_of::<u32>() as isize;
+                    tsize = (*byte_end as isize) - start + 1;
+                }
+                if tsize > 0 {
+                    let tmp = walker.instruction_bytes(start as usize, tsize as usize)?;
+                    res = res.checked_shl(8 * tsize as u32).unwrap_or(0);
+                    res = (res as u64 | tmp as u64) as i64;
+                }
+
+                res = if !big_endian { bits::byte_swap(res, size) } else { res };
+                res = res.checked_shr(*shift).unwrap_or(if res < 0 { -1 } else { 0 });
+
+                let value = if *sign_bit {
+                    bits::sign_extend(res, bit_end - bit_start)
+                } else {
+                    bits::zero_extend(res, bit_end - bit_start)
+                };
+
+                let offset = (*byte_start + walker.offset(None)) as u32 * 8;
+                let end_offset = size as u32 * 8;
+
+                (value, Some(offset + end_offset - (*bit_end as u32 + 1)..offset + end_offset - *bit_start as u32))
+            },
+            Self::ContextField {
+                sign_bit,
+                bit_start,
+                bit_end,
+                byte_start,
+                byte_end,
+                shift,
+            } => {
+                let mut res = 0i64;
+                let mut size = (*byte_end as isize) - (*byte_start as isize) + 1;
+                let mut start = *byte_start as isize;
+
+                while size >= size_of::<u32>() as isize {
+                    let tmp = walker.context_bytes(start as usize, size_of::<u32>());
+                    res = res.checked_shl(8 * size_of::<u32>() as u32).unwrap_or(0);
+                    res = (res as u64 | tmp as u64) as i64;
+                    start += size_of::<u32>() as isize;
+                    size = (*byte_end as isize) - start + 1;
+                }
+                if size > 0 {
+                    let tmp = walker.context_bytes(start as usize, size as usize);
+                    res = res.checked_shl(8 * size as u32).unwrap_or(0);
+                    res = (res as u64 | tmp as u64) as i64;
+                }
+
+                res = res.checked_shr(*shift).unwrap_or(if res < 0 { -1 } else { 0 });
+
+                let value = if *sign_bit {
+                    bits::sign_extend(res, bit_end - bit_start)
+                } else {
+                    bits::zero_extend(res, bit_end - bit_start)
+                };
+
+                let offset = (*byte_start + walker.offset(None)) as u32 * 8;
+                let end_offset = size as u32 * 8;
+
+                (value, Some(offset + end_offset - (*bit_end as u32 + 1)..offset + end_offset - *bit_start as u32))
+            },
+            Self::Constant { value } => (*value, None),
+            Self::Operand {
+                table_id,
+                constructor_id,
+                index,
+            } => {
+                let table = symbols.unchecked_symbol(*table_id); //.ok_or_else(|| Error::InvalidSymbol)?;
+                let ctor = if let Symbol::Subtable { constructors, .. } = table {
+                    unsafe { constructors.get_unchecked(*constructor_id) }
+                } else {
+                    unreachable!()
+                    //return Err(Error::InconsistentState)
+                };
+
+                let pexp = if let Symbol::Operand {
+                    def_expr,
+                    subsym_id,
+                    ..
+                } = symbols.unchecked_symbol(ctor.operand(*index)) /* .ok_or_else(|| Error::InvalidSymbol)? */ {
+                    if let Some(def_expr) = def_expr {
+                        def_expr
+                    } else if let Some(subsym_id) = subsym_id {
+                        let sym = symbols.unchecked_symbol(*subsym_id); /* .ok_or_else(|| Error::InvalidSymbol)?; */
+                        sym.pattern_value()
+                    } else {
+                        return Ok((0, None))
+                    }
+                } else {
+                    unreachable!()
+                    //return Err(Error::InconsistentState)
+                };
+
+                let (value, bits) = walker.resolve_with_bits(pexp, ctor, *index, symbols)?;
+                (value, bits.map(|r| {
+                    let offset = 0; //walker.offset(None) as u32 * 8;
+                    r.start + offset..r.end + offset
+                }))
+            },
+            Self::StartInstruction => (walker.address().offset() as i64, None),
+            Self::EndInstruction => (walker.next_address().map(|a| a.offset() as i64).unwrap_or(0), None),
+            Self::Plus(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.wrapping_add(r), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Sub(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.wrapping_sub(r), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Mult(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.wrapping_mul(r), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::LeftShift(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.checked_shl(r as u8 as u32).unwrap_or(0), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::RightShift(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.checked_shr(r as u8 as u32)
+                    .unwrap_or(if l < 0 { -1 } else { 0 }), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::And(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l & r, match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Or(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l | r, match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Xor(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l ^ r, match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Div(ref lhs, ref rhs) => {
+                let (l, m) = lhs.value_with(walker, symbols)?;
+                let (r, n) = rhs.value_with(walker, symbols)?;
+
+                (l.wrapping_div(r), match (m, n) {
+                    (None, v) | (v, None) => v,
+                    (Some(r1), Some(r2)) => Some(r1.start.min(r2.start)..r1.end.max(r2.end))
+                })
+            },
+            Self::Minus(ref operand) => {
+                let (operand, m) = operand.value_with(walker, symbols)?;
+                (-operand, m)
+            },
+            Self::Not(ref operand) => {
+                let (operand, m) = operand.value_with(walker, symbols)?;
+                (!operand, m)
+            },
+        })
     }
 
     pub fn value<'b, 'c, 'z>(&'b self, walker: &mut ParserWalker<'b, 'c, 'z>, symbols: &'b SymbolTable) -> Result<i64, Error> {

--- a/fugue-ir/src/disassembly/symbol/symbol.rs
+++ b/fugue-ir/src/disassembly/symbol/symbol.rs
@@ -465,12 +465,12 @@ impl Symbol {
                         sym.collect_operands(arena, operands, walker, symbols);
                     }
                 } else {
-                    let value = if let Some(ref def_expr) = def_expr {
-                        def_expr.value(walker, symbols).unwrap()
+                    let (value, bits) = if let Some(ref def_expr) = def_expr {
+                        def_expr.value_with(walker, symbols).unwrap()
                     } else {
                         unreachable!()
                     };
-                    operands.push(value);
+                    operands.push_with(value, bits);
                 }
                 walker.unchecked_pop_operand();
             }
@@ -487,12 +487,12 @@ impl Symbol {
                 varnode_table,
                 ..
             } => {
-                let index = pattern_value.value(walker, symbols).unwrap();
+                let (index, bits) = pattern_value.value_with(walker, symbols).unwrap();
                 if index >= 0 && (index as usize) < varnode_table.len() {
                     let named = symbols.unchecked_symbol(unsafe {
                         varnode_table.get_unchecked(index as usize).unsafe_unwrap()
                     });
-                    operands.push(named.name());
+                    operands.push_with(named.name(), bits);
                 }
             }
             Self::Name {
@@ -500,24 +500,24 @@ impl Symbol {
                 name_table,
                 ..
             } => {
-                let index = pattern_value.value(walker, symbols).unwrap() as usize;
-                operands.push(name_table[index].as_str());
+                let (index, bits) = pattern_value.value_with(walker, symbols).unwrap();
+                operands.push_with(name_table[index as usize].as_str(), bits);
             }
             Self::Epsilon { .. } => {
                 operands.push(0i64);
             }
             Self::Value { pattern_value, .. } => {
-                let value = pattern_value.value(walker, symbols).unwrap();
-                operands.push(value);
+                let (value, bits) = pattern_value.value_with(walker, symbols).unwrap();
+                operands.push_with(value, bits);
             }
             Self::ValueMap {
                 pattern_value,
                 value_table,
                 ..
             } => {
-                let index = pattern_value.value(walker, symbols).unwrap() as usize;
-                let value = *unsafe { value_table.get_unchecked(index) };
-                operands.push(value);
+                let (index, bits) = pattern_value.value_with(walker, symbols).unwrap();
+                let value = *unsafe { value_table.get_unchecked(index as usize) };
+                operands.push_with(value, bits);
             }
             Self::Start { .. } => {
                 operands.push(walker.address());


### PR DESCRIPTION
Changing from interval to iset introduced a bug, where some segments are not imported and gives NoBlockSegment error. 
This pull request is for fixing that. 
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: NoBlockSegment(4293104490)', src/bin/rh850_canid.rs:84:31
stack backtrace:
   0: rust_begin_unwind
             at /rustc/398fa2187c88de46c13c142f600064483a563c86/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/398fa2187c88de46c13c142f600064483a563c86/library/core/src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at /rustc/398fa2187c88de46c13c142f600064483a563c86/library/core/src/result.rs:1651:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/398fa2187c88de46c13c142f600064483a563c86/library/core/src/result.rs:1076:23
   4: rh850_canid::main
             at ./src/bin/rh850_canid.rs:84:14
   5: core::ops::function::FnOnce::call_once
             at /rustc/398fa2187c88de46c13c142f600064483a563c86/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```