### PR TITLE
allow to initialise ArchitectureDef from str with missing variant

### DIFF
--- a/fugue-arch/src/lib.rs
+++ b/fugue-arch/src/lib.rs
@@ -33,8 +33,8 @@ impl FromStr for ArchitectureDef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts = s.splitn(4, ':').collect::<Vec<_>>();
-        if parts.len() != 4 {
-            return Err(ArchDefParseError::ParseFormat)
+        if !matches!(parts.len(), 3 | 4) {
+            return Err(ArchDefParseError::ParseFormat);
         }
 
         let processor = parts[0];
@@ -43,11 +43,16 @@ impl FromStr for ArchitectureDef {
             "be" | "BE" => Endian::Big,
             _ => return Err(ArchDefParseError::ParseEndian),
         };
-        let bits = parts[2].parse::<usize>()
+        let bits = parts[2]
+            .parse::<usize>()
             .map_err(|_| ArchDefParseError::ParseBits)?;
-        let variant = parts[3];
 
-        Ok(ArchitectureDef::new(processor, endian, bits, variant))
+        Ok(ArchitectureDef::new(
+            processor,
+            endian,
+            bits,
+            *parts.get(3).unwrap_or(&"default"),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR allows ArchitectureDef to be initialised from a string without a variant.

For example, when using:

```rust
ArchitectureDef::from_str("ARM:LE:32")
```

we will have `Ok(ArchitectureDef{...})` this instead of Err:

```
Ok(
    ArchitectureDef {
        processor: "ARM",
        endian: Little,
        bits: 32,
        variant: "default",
    },
)
```