### PR TITLE
handle potential OOB access during ParserContext construction

### DIFF
--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ir"
-version = "0.2.101"
+version = "0.2.102"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"

--- a/fugue-ir/src/disassembly/error.rs
+++ b/fugue-ir/src/disassembly/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
     InvalidSpace,
     #[error("handle invalid")]
     InvalidHandle,
+    #[error("offset invalid")]
+    InvalidOffset,
     #[error("inconsistent disassembly state")]
     InconsistentState,
     #[error("{0}")]

--- a/fugue-ir/src/translator.rs
+++ b/fugue-ir/src/translator.rs
@@ -507,18 +507,25 @@ impl Translator {
         address: AddressValue,
         bytes: &[u8],
     ) -> Result<Instruction<'z>, Error> {
-        self.disassemble_aux(db, context, arena, address, bytes, |fmt, delay_slots, length| {
-            let mnemonic = fmt.mnemonic_str(builder);
-            let operands = fmt.operands_str(builder);
+        self.disassemble_aux(
+            db,
+            context,
+            arena,
+            address,
+            bytes,
+            |fmt, delay_slots, length| {
+                let mnemonic = fmt.mnemonic_str(builder);
+                let operands = fmt.operands_str(builder);
 
-            Ok(Instruction {
-                address,
-                mnemonic,
-                operands,
-                delay_slots,
-                length,
-            })
-        })
+                Ok(Instruction {
+                    address,
+                    mnemonic,
+                    operands,
+                    delay_slots,
+                    length,
+                })
+            },
+        )
     }
 
     pub fn disassemble_full<'a, 'az, 'z>(
@@ -530,20 +537,27 @@ impl Translator {
         address: AddressValue,
         bytes: &[u8],
     ) -> Result<InstructionFull<'a, 'z>, Error> {
-        self.disassemble_aux(db, context, arena, address, bytes, |fmt, delay_slots, length| {
-            let mnemonic = fmt.mnemonic_str(builder);
-            let operands = fmt.operands_str(builder);
-            let operand_data = fmt.operand_data(builder);
+        self.disassemble_aux(
+            db,
+            context,
+            arena,
+            address,
+            bytes,
+            |fmt, delay_slots, length| {
+                let mnemonic = fmt.mnemonic_str(builder);
+                let operands = fmt.operands_str(builder);
+                let operand_data = fmt.operand_data(builder);
 
-            Ok(InstructionFull {
-                address,
-                mnemonic,
-                operands,
-                operand_data,
-                delay_slots,
-                length,
-            })
-        })
+                Ok(InstructionFull {
+                    address,
+                    mnemonic,
+                    operands,
+                    operand_data,
+                    delay_slots,
+                    length,
+                })
+            },
+        )
     }
 
     pub fn lift_pcode_raw<'z>(
@@ -599,7 +613,9 @@ impl Translator {
                     arena,
                     db,
                     address.clone() + fall_offset,
-                    &bytes[fall_offset..],
+                    &bytes
+                        .get(fall_offset..)
+                        .ok_or(DisassemblyError::InvalidOffset)?,
                 );
                 let mut dwalker = ParserWalker::new(&mut dcontext);
 
@@ -908,7 +924,8 @@ impl Translator {
                 let operand = unsafe { symbol_table.unchecked_symbol(ct.operand(op)) };
                 //.ok_or_else(|| DisassemblyError::InvalidSymbol)?;
 
-                let offset = unsafe { walker.offset(operand.offset_base()) } + operand.relative_offset();
+                let offset =
+                    unsafe { walker.offset(operand.offset_base()) } + operand.relative_offset();
 
                 walker.unchecked_allocate_operand(op);
                 walker.set_offset(offset)?;

--- a/fugue-ir/src/translator.rs
+++ b/fugue-ir/src/translator.rs
@@ -708,7 +708,9 @@ impl Translator {
                     arena,
                     db,
                     address.clone() + fall_offset,
-                    &bytes.get(fall_offset..).ok_or(DisassemblyError::InvalidOffset)?,
+                    &bytes
+                        .get(fall_offset..)
+                        .ok_or(DisassemblyError::InvalidOffset)?,
                 );
                 let mut dwalker = ParserWalker::new(&mut dcontext);
 
@@ -801,7 +803,9 @@ impl Translator {
                     arena,
                     db,
                     address.clone() + fall_offset,
-                    &bytes.get(fall_offset..).ok_or(DisassemblyError::InvalidOffset)?,
+                    &bytes
+                        .get(fall_offset..)
+                        .ok_or(DisassemblyError::InvalidOffset)?,
                 );
                 let mut dwalker = ParserWalker::new(&mut dcontext);
 

--- a/fugue-ir/src/translator.rs
+++ b/fugue-ir/src/translator.rs
@@ -708,7 +708,7 @@ impl Translator {
                     arena,
                     db,
                     address.clone() + fall_offset,
-                    &bytes[fall_offset..],
+                    &bytes.get(fall_offset..).ok_or(DisassemblyError::InvalidOffset)?,
                 );
                 let mut dwalker = ParserWalker::new(&mut dcontext);
 
@@ -801,7 +801,7 @@ impl Translator {
                     arena,
                     db,
                     address.clone() + fall_offset,
-                    &bytes[fall_offset..],
+                    &bytes.get(fall_offset..).ok_or(DisassemblyError::InvalidOffset)?,
                 );
                 let mut dwalker = ParserWalker::new(&mut dcontext);
 


### PR DESCRIPTION
It's possible to cause a panic if the range start index exceeds the buffer length. This PR should eliminate potential panics.