### PR TITLE
add support for return-thunk property in fspec

### DIFF
--- a/fugue-fspec/Cargo.toml
+++ b/fugue-fspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-fspec"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"

--- a/fugue-fspec/src/fspec.rs
+++ b/fugue-fspec/src/fspec.rs
@@ -29,7 +29,9 @@ bitflags! {
     #[repr(transparent)]
     pub struct FunctionProperties: u8 {
         const NON_RETURNING = 0b0000_0001;
-        const RETURN_THUNK = 0b0000_0010;
+
+        const TAIL = 0b0000_0010;
+        const RETURN_THUNK = Self::TAIL.bits();
     }
 }
 
@@ -38,6 +40,7 @@ bitflags! {
 enum FunctionProperty {
     NonReturning,
     ReturnThunk,
+    Tail,
 }
 
 impl From<OneOrMany<FunctionProperty>> for FunctionProperties {
@@ -54,8 +57,8 @@ impl From<Vec<FunctionProperty>> for FunctionProperties {
                 FunctionProperty::NonReturning => {
                     props.insert(FunctionProperties::NON_RETURNING);
                 }
-                FunctionProperty::ReturnThunk => {
-                    props.insert(FunctionProperties::RETURN_THUNK);
+                FunctionProperty::Tail | FunctionProperty::ReturnThunk => {
+                    props.insert(FunctionProperties::TAIL);
                 }
             }
         }
@@ -71,8 +74,8 @@ impl From<FunctionProperties> for Vec<FunctionProperty> {
                 FunctionProperties::NON_RETURNING => {
                     props.push(FunctionProperty::NonReturning);
                 }
-                FunctionProperties::RETURN_THUNK => {
-                    props.push(FunctionProperty::ReturnThunk);
+                FunctionProperties::TAIL => {
+                    props.push(FunctionProperty::Tail);
                 }
                 _ => (),
             }
@@ -502,6 +505,31 @@ patterns:
             arch: Language::new("x86", Endian::Little),
             platform: "uefi",
         }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tail() -> Result<(), Box<dyn std::error::Error>> {
+        let input = r#"
+name: __x86_return_thunk
+properties: return-thunk
+where:
+  all:
+  - arch: x86:LE:64
+  - platform: posix
+patterns:
+- x86:LE:64:
+    patterns:
+    - F3 0F 1E FA C3
+"#;
+
+        let fspec = serde_yaml::from_str::<FunctionSpec>(input)?;
+
+        assert_eq!(fspec.name, "__x86_return_thunk");
+        assert!(fspec.properties.contains(FunctionProperties::TAIL));
+        assert!(fspec.properties.contains(FunctionProperties::RETURN_THUNK));
+        assert_eq!(fspec.patterns.len(), 1);
 
         Ok(())
     }

--- a/fugue-fspec/src/fspec.rs
+++ b/fugue-fspec/src/fspec.rs
@@ -29,6 +29,7 @@ bitflags! {
     #[repr(transparent)]
     pub struct FunctionProperties: u8 {
         const NON_RETURNING = 0b0000_0001;
+        const RETURN_THUNK = 0b0000_0010;
     }
 }
 
@@ -36,6 +37,7 @@ bitflags! {
 #[serde(rename_all = "kebab-case")]
 enum FunctionProperty {
     NonReturning,
+    ReturnThunk,
 }
 
 impl From<OneOrMany<FunctionProperty>> for FunctionProperties {
@@ -52,6 +54,9 @@ impl From<Vec<FunctionProperty>> for FunctionProperties {
                 FunctionProperty::NonReturning => {
                     props.insert(FunctionProperties::NON_RETURNING);
                 }
+                FunctionProperty::ReturnThunk => {
+                    props.insert(FunctionProperties::RETURN_THUNK);
+                }
             }
         }
         props
@@ -65,6 +70,9 @@ impl From<FunctionProperties> for Vec<FunctionProperty> {
             match prop {
                 FunctionProperties::NON_RETURNING => {
                     props.push(FunctionProperty::NonReturning);
+                }
+                FunctionProperties::RETURN_THUNK => {
+                    props.push(FunctionProperty::ReturnThunk);
                 }
                 _ => (),
             }


### PR DESCRIPTION
Adding `tail`/`return-thunk` property in order to mark functions such as `__x86_return_thunk` etc.