### PR TITLE
Stricter alignment checks when disassembling ARM

### DIFF
--- a/fugue-ir/src/disassembly/context.rs
+++ b/fugue-ir/src/disassembly/context.rs
@@ -356,6 +356,10 @@ impl ContextDatabase {
         bits.get(&self.database.get_or_default(&address).values)
     }
 
+    pub fn try_get_variable_by_bits(&self, bits: &ContextBitRange, address: AddressValue) -> Option<u32> {
+        self.database.get(&address).map(|ctx| bits.get(&ctx.values))
+    }
+
     pub fn get_variable<S: Borrow<str>>(&self, name: S, address: AddressValue) -> Option<u32> {
         self.variable(name.borrow())
             .map(|bits| self.get_variable_by_bits(bits, address))

--- a/fugue-ir/src/translator.rs
+++ b/fugue-ir/src/translator.rs
@@ -18,6 +18,7 @@ use crate::address::AddressValue;
 use crate::deserialise::parse::XmlExt;
 use crate::deserialise::Error as DeserialiseError;
 
+use crate::disassembly::context::ContextBitRange;
 use crate::disassembly::lift::{FloatFormats, UserOpStr};
 use crate::disassembly::symbol::{FixedHandle, Symbol, SymbolScope, SymbolTable};
 use crate::disassembly::walker::InstructionFormatter;
@@ -42,6 +43,8 @@ use crate::convention::Convention;
 
 use crate::register::RegisterNames;
 use crate::space_manager::SpaceManager;
+
+pub const TMODE_CONTEXT: ContextBitRange = ContextBitRange::new(0, 0);
 
 // Translator is used for parsing the processor spec XML and
 // lifting instructions
@@ -465,11 +468,17 @@ impl Translator {
         F: FnMut(InstructionFormatter<'a, 'c, 'az>, usize, usize) -> Result<T, E>,
         E: From<Error>,
     {
-        if self.alignment() != 1 {
-            if address.offset() % self.alignment() as u64 != 0 {
+        let alignment = match db.try_get_variable_by_bits(&TMODE_CONTEXT, address) {
+            Some(1) => 2,
+            Some(_) => 4,
+            None => self.alignment(),
+        };
+
+        if alignment != 1 {
+            if address.offset() % alignment as u64 != 0 {
                 return Err(DisassemblyError::IncorrectAlignment {
                     address: address.offset(),
-                    alignment: self.alignment(),
+                    alignment,
                 })
                 .map_err(Error::from)?;
             }
@@ -582,11 +591,17 @@ impl Translator {
         address: AddressValue,
         bytes: &[u8],
     ) -> Result<PCodeRaw<'z>, Error> {
-        if self.alignment != 1 {
-            if address.offset() % self.alignment as u64 != 0 {
+        let alignment = match db.try_get_variable_by_bits(&TMODE_CONTEXT, address) {
+            Some(1) => 2,
+            Some(_) => 4,
+            None => self.alignment(),
+        };
+
+        if alignment != 1 {
+            if address.offset() % alignment as u64 != 0 {
                 return Err(DisassemblyError::IncorrectAlignment {
                     address: address.offset(),
-                    alignment: self.alignment,
+                    alignment,
                 })?;
             }
         }


### PR DESCRIPTION
This adds alignment checking during disassembly / lifting based on the current value of the `TMode` context variable.