### PR TITLE
fix: use fugue-bv with default features in fugue-ir

### DIFF
--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -20,7 +20,7 @@ extra-logging = []
 ahash = { version = "0.8", features = ["serde"] }
 bumpalo = { version = "3.12", features = ["boxed", "collections"] }
 fugue-arch = { path = "../fugue-arch", version = "0.2" }
-fugue-bv = { path = "../fugue-bv", version = "0.2", default-features = false }
+fugue-bv = { path = "../fugue-bv", version = "0.2" }
 fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
 iset = { version = "0.3", features = ["serde"], package = "fugue-iset" }
 itertools = "0.10"


### PR DESCRIPTION
Changes in https://github.com/fugue-re/fugue-core/pull/28 led to build errors in certain `fugue-*` crates. I've enforced default features usage for fugue-bv to fix the builds.