### PR TITLE
feat: simplify bigint features

### DIFF
--- a/fugue-bv/Cargo.toml
+++ b/fugue-bv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-bv"
-version = "0.2.36"
+version = "0.2.37"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
@@ -8,12 +8,12 @@ description = "A binary analysis framework written in Rust"
 homepage = "https://fugue.re"
 
 [features]
-default = ["bigint-rug"]
+default = ["bigint"]
 fixed-u64 = []
 fixed-u128 = []
-bigint = []
-bigint-malachite = ["bigint", "malachite"]
-bigint-rug = ["bigint", "rug"]
+bigint = ["bigint-rug"]
+bigint-malachite = ["malachite"]
+bigint-rug = ["rug"]
 
 [dependencies]
 fugue-bytes = { path = "../fugue-bytes", version = "0.2" }

--- a/fugue-bv/src/core_bigint/mod.rs
+++ b/fugue-bv/src/core_bigint/mod.rs
@@ -1,24 +1,15 @@
 #[cfg(all(feature = "bigint-malachite", feature = "bigint-rug"))]
 compile_error!("features `bigint-malachite` and `bigint-rug` are mutually exclusive.");
 
-#[cfg(any(
-    feature = "bigint-malachite",
-    all(feature = "bigint", not(feature = "bigint-rug"), target_os = "windows")
-))]
+#[cfg(feature = "bigint-malachite")]
 mod core_bigint_malachite;
-#[cfg(any(
-    feature = "bigint-malachite",
-    all(feature = "bigint", not(feature = "bigint-rug"), target_os = "windows")
-))]
+#[cfg(feature = "bigint-malachite")]
 pub use self::core_bigint_malachite::*;
 
-#[cfg(any(
-    feature = "bigint-rug",
-    all(feature = "bigint", not(feature = "bigint-malachite"), not(target_os = "windows"))
-))]
+#[cfg(all(feature = "bigint-rug", target_os = "windows"))]
+compile_error!("feature `bigint-rug` is not supported on Windows.");
+
+#[cfg(feature = "bigint-rug")]
 mod core_bigint_rug;
-#[cfg(any(
-    feature = "bigint-rug",
-    all(feature = "bigint", not(feature = "bigint-malachite"), not(target_os = "windows"))
-))]
+#[cfg(feature = "bigint-rug")]
 pub use core_bigint_rug::*;

--- a/fugue-bv/src/lib.rs
+++ b/fugue-bv/src/lib.rs
@@ -1,12 +1,12 @@
-#[cfg(feature = "bigint")]
+#[cfg(any(feature = "bigint-malachite", feature = "bigint-rug"))]
 pub mod core_bigint;
-#[cfg(feature = "bigint")]
+#[cfg(any(feature = "bigint-malachite", feature = "bigint-rug"))]
 pub mod core_mixed;
 pub mod core_u64;
 pub mod core_u128;
 pub mod error;
 
-#[cfg(feature = "bigint")]
+#[cfg(any(feature = "bigint-malachite", feature = "bigint-rug"))]
 pub use core_mixed::*;
 #[cfg(feature = "fixed-u64")]
 pub use core_u64::*;

--- a/fugue-core/Cargo.toml
+++ b/fugue-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Sam Thomas <st@xv.ax>", "Zitai Chen <zitaichen@outlook.com>"]
 edition = "2021"
 license = "MIT"
@@ -9,11 +9,13 @@ homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]
+
 bigint = ["bigint-rug"]
-bigint-rug = ["fugue-bv/bigint-rug", "fugue-db?/bigint", "fugue-ir/bigint"]
-bigint-malachite = ["fugue-bv/bigint-malachite", "fugue-db?/bigint", "fugue-ir/bigint"]
-fixed-u64 = ["fugue-bv/fixed-u64", "fugue-db?/fixed-u64", "fugue-ir/fixed-u64"]
-fixed-u128 = ["fugue-bv/fixed-u128", "fugue-db?/fixed-u128", "fugue-ir/fixed-u128"]
+bigint-rug = ["fugue-bv/bigint-rug", "fugue-db?/bigint-malachite", "fugue-fspec/bigint-rug", "fugue-ir/bigint-rug", "fugue-sleigh/bigint-rug"]
+bigint-malachite = ["fugue-bv/bigint-malachite", "fugue-db?/bigint-malachite", "fugue-fspec/bigint-malachite", "fugue-ir/bigint-malachite", "fugue-sleigh/bigint-malachite"]
+
+fixed-u64 = ["fugue-bv/fixed-u64", "fugue-db?/fixed-u64", "fugue-fspec/fixed-u64", "fugue-ir/fixed-u64", "fugue-sleigh/fixed-u64"]
+fixed-u128 = ["fugue-bv/fixed-u128", "fugue-db?/fixed-u128", "fugue-fspec/fixed-u128", "fugue-ir/fixed-u128", "fugue-sleigh/fixed-u128"]
 
 extra-logging = ["fugue-ir/extra-logging"]
 extra-integer-types = ["fugue-bytes/extra-integer-types"]
@@ -27,6 +29,6 @@ fugue-bv = { path = "../fugue-bv", version = "0.2", default-features = false }
 fugue-bytes = { path = "../fugue-bytes", version = "0.2" }
 fugue-db = { path = "../fugue-db", version = "0.2", default-features = false, optional = true }
 fugue-fp = { path = "../fugue-fp", version = "0.2", optional = true }
-fugue-fspec = { path = "../fugue-fspec", version = "0.2" }
+fugue-fspec = { path = "../fugue-fspec", version = "0.2", default-features = false }
 fugue-ir = { path = "../fugue-ir", version = "0.2", default-features = false }
-fugue-sleigh = { path = "../fugue-sleigh", version = "0.2" }
+fugue-sleigh = { path = "../fugue-sleigh", version = "0.2", default-features = false }

--- a/fugue-core/src/lib.rs
+++ b/fugue-core/src/lib.rs
@@ -1,3 +1,15 @@
+#[cfg(all(
+    feature = "fp",
+    any(
+        feature = "bigint-malachite",
+        feature = "fixed-u64",
+        feature = "fixed-u128",
+    )
+))]
+compile_error!(
+    "the `fp` feature is only compatible with the default `bigint`/`bigint-rug` feature"
+);
+
 pub use fugue_bv as bv;
 #[cfg(feature = "db")]
 pub use fugue_db as db;

--- a/fugue-db/Cargo.toml
+++ b/fugue-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-db"
-version = "0.2.17"
+version = "0.2.18"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 build = "build.rs"
@@ -10,7 +10,11 @@ homepage = "https://fugue.re"
 
 [features]
 default = ["bigint"]
-bigint = ["fugue-ir/bigint"]
+
+bigint = ["bigint-rug"]
+bigint-malachite = ["fugue-ir/bigint-malachite"]
+bigint-rug = ["fugue-ir/bigint-rug"]
+
 fixed-u64 = ["fugue-ir/fixed-u64"]
 fixed-u128 = ["fugue-ir/fixed-u128"]
 

--- a/fugue-db/Cargo.toml
+++ b/fugue-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-db"
-version = "0.2.18"
+version = "0.2.17"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 build = "build.rs"

--- a/fugue-fp/Cargo.toml
+++ b/fugue-fp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-fp"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
@@ -8,7 +8,7 @@ description = "A binary analysis framework written in Rust"
 homepage = "https://fugue.re"
 
 [dependencies]
-fugue-bv = { path = "../fugue-bv", version = "0.2", features = ["bigint"], default-features = false }
-fugue-ir = { path = "../fugue-ir", version = "0.2" }
+fugue-bv = { path = "../fugue-bv", version = "0.2", features = ["bigint-rug"], default-features = false }
+fugue-ir = { path = "../fugue-ir", version = "0.2", features = ["bigint-rug"], default-features = false }
 rug = { version = "1", features = ["float"] }
 thiserror = "1"

--- a/fugue-fspec/Cargo.toml
+++ b/fugue-fspec/Cargo.toml
@@ -1,18 +1,28 @@
 [package]
 name = "fugue-fspec"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
 description = "A binary analysis framework written in Rust"
 homepage = "https://fugue.re"
 
+[features]
+default = ["bigint"]
+
+bigint = ["bigint-rug"]
+bigint-malachite = ["fugue-ir/bigint-malachite", "fugue-sleigh/bigint-malachite"]
+bigint-rug = ["fugue-ir/bigint-rug", "fugue-sleigh/bigint-rug"]
+
+fixed-u64 = ["fugue-ir/fixed-u64", "fugue-sleigh/fixed-u64"]
+fixed-u128 = ["fugue-ir/fixed-u128", "fugue-sleigh/fixed-u128"]
+
 [dependencies]
 bitflags = { version = "2", features = ["serde"] }
 fugue-arch = { version = "0.2", path = "../fugue-arch" }
 fugue-bytes = { version = "0.2", path = "../fugue-bytes" }
-fugue-ir = { version = "0.2", path = "../fugue-ir" }
-fugue-sleigh = { version = "0.2", path = "../fugue-sleigh" }
+fugue-ir = { version = "0.2", path = "../fugue-ir", default-features = false }
+fugue-sleigh = { version = "0.2", path = "../fugue-sleigh", default-features = false }
 nom = "7"
 regex = "1"
 serde = "1"

--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ir"
-version = "0.2.103"
+version = "0.2.104"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
@@ -10,7 +10,10 @@ homepage = "https://fugue.re"
 [features]
 default = ["bigint"]
 
-bigint = ["fugue-bv/bigint"]
+bigint = ["bigint-rug"]
+bigint-malachite = ["fugue-bv/bigint-malachite"]
+bigint-rug = ["fugue-bv/bigint-rug"]
+
 fixed-u64 = ["fugue-bv/fixed-u64"]
 fixed-u128 = ["fugue-bv/fixed-u128"]
 

--- a/fugue-ir/Cargo.toml
+++ b/fugue-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ir"
-version = "0.2.104"
+version = "0.2.103"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"

--- a/fugue-sleigh/Cargo.toml
+++ b/fugue-sleigh/Cargo.toml
@@ -1,15 +1,25 @@
 [package]
 name = "fugue-sleigh"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Sam Thomas <st@xv.ax>"]
 edition = "2021"
 license = "MIT"
 description = "A binary analysis framework written in Rust"
 homepage = "https://fugue.re"
 
+[features]
+default = ["bigint"]
+
+bigint = ["bigint-rug"]
+bigint-malachite = ["fugue-ir/bigint-malachite"]
+bigint-rug = ["fugue-ir/bigint-rug"]
+
+fixed-u64 = ["fugue-ir/fixed-u64"]
+fixed-u128 = ["fugue-ir/fixed-u128"]
+
 [dependencies]
 arrayvec = "0.7"
-fugue-ir = { path = "../fugue-ir", version = "0.2" }
+fugue-ir = { path = "../fugue-ir", version = "0.2", default-features = false }
 itertools = "0.13"
 once_cell = "1"
 pest = "2.6"


### PR DESCRIPTION
This PR allows us to control usage of `bigint` features from any "entrypoint" crate, not just `fugue` and `fugue-ir`; it simplifies and unifies the features across all crates and adds more sanity checking.